### PR TITLE
Fix TTL parsing when generating token

### DIFF
--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -395,7 +395,7 @@ class JWTGuard implements Guard
         }
 
         $time   = Carbon::now();
-        $expiry = CarbonInterval::fromString($this->config['ttl']);
+        $expiry = new CarbonInterval($this->config['ttl']);
 
         return (new Builder)
             ->issuedBy(config('app.url'))


### PR DESCRIPTION
When reading TTL value, which is an ISO interval string, one should use `CarbonInterval` constructor, rather than `fromString` method, as explained in this issue: https://github.com/briannesbitt/Carbon/issues/1973#issuecomment-569961455

This should also "fix" the issue (https://github.com/sprocketbox/laravel-jwt/issues/2) with 1 minute token validity 